### PR TITLE
Sudoers config

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -18,9 +18,6 @@
 - {import_tasks: netdata.yml, tags: netdata}
 - {import_tasks: system-config.yml, tags: system}
 
-- name: enable sudo with no password for sudoers
-  lineinfile: dest=/etc/sudoers state=present regexp='^%cicadministrators ALL\=' line='%cicadministrators ALL=(ALL) NOPASSWD:ALL' validate='visudo -cf %s'
-
 - name: Set default locale to en_CA.UTF-8
   debconf:
     name: locales

--- a/roles/common/tasks/system-config.yml
+++ b/roles/common/tasks/system-config.yml
@@ -2,3 +2,16 @@
   ansible.builtin.user:
     name: root
     comment: "root@{{ ansible_facts['nodename'] }}"
+
+- name: configure sudo email address
+  lineinfile:
+    path: /etc/sudoers.d/99-sudoers-config
+    create: yes
+    line: "Defaults mailfrom=\"{{ ansible_facts['nodename'] }}@douglas.mcgill.ca\""
+    validate: 'visudo -cf %s'
+
+- name: add cicadministrators to sudoers
+  lineinfile:
+    path: /etc/sudoers.d/99-sudoers-config
+    line: "%cicadministrators ALL=(ALL) NOPASSWD:ALL"
+    validate: 'visudo -cf %s'


### PR DESCRIPTION
tested the creation of the 99-sudoers-config file and the cicadministrators are properly placed in to the sudo group.  I just did some failed sudo attempts on cicws45 from the testuser account so please verify that the email it's sent from looks good.