### PR TITLE
add /etc/profile loading to /etc/zsh/zprofile

### DIFF
--- a/roles/workstation/tasks/file-config.yml
+++ b/roles/workstation/tasks/file-config.yml
@@ -92,3 +92,9 @@
     path: /etc/X11/Xsession
     regexp: '^ERRFILE='
     line: 'ERRFILE=/var/tmp/xdgcache-$USER/.xsession-errors'
+
+- name: add /etc/profile loading to /etc/zsh/zprofile
+  lineinfile:
+    path: /etc/zsh/zprofile
+    line: "emulate sh -c 'source /etc/profile'"
+    create: yes


### PR DESCRIPTION
solves #64 i think.  It adds the /etc/profile to the zprofile.  @joshunrau do you want to test this?  I can run this play on your machine.  let me know.