### PR TITLE
add enable sysreq key via builtin module

### DIFF
--- a/roles/workstation/tasks/file-config.yml
+++ b/roles/workstation/tasks/file-config.yml
@@ -98,3 +98,12 @@
     path: /etc/zsh/zprofile
     line: "emulate sh -c 'source /etc/profile'"
     create: yes
+
+# enable sysrq key to hard reboot: https://forum.endeavouros.com/t/tip-enable-magic-sysrq-key-reisub/7576
+- name: enable sysrq key
+  ansible.posix.sysctl:
+    name: kernel.sysrq
+    value: '1'
+    state: present
+    reload: yes
+


### PR DESCRIPTION
I verified the systcl.conf file and its update properly.  I haven't tried using it yet because i have to be there in person, but I see no reason why it won't work.  You can wait to merge this until 2024 if you want me to do a in person test.