### PR TITLE
Update to centralized mail relay

### DIFF
--- a/files/msmtprc
+++ b/files/msmtprc
@@ -4,7 +4,7 @@
 account default
 
 # The SMTP smarthost
-host relaissmtp.rtss.qc.ca
+host cicvmhost01.douglas.rtss.qc.ca
 port 25
 
 # Construct envelope-from addresses of the form "user@oursite.example"


### PR DESCRIPTION
I installed and configured postfix on cicvmhost01, which is a stable server which is accessible from all systems *and* can forward mail on to the internal relay properly. I've pushed this config to all live machines, and manually configured the remaining servers.