### PR TITLE
Add SSH access policy for restricting logins by group membership

### DIFF
--- a/group_vars/pi_workstations.yml
+++ b/group_vars/pi_workstations.yml
@@ -1,0 +1,6 @@
+ssh_access_policy_enabled: true
+ssh_access_policy_file: /etc/ssh/sshd_config.d/50-ssh-access-policy.conf
+ssh_access_allow_groups: [pis, cicadministrators, sudo]
+ssh_access_allow_users: []
+ssh_access_deny_groups: []
+ssh_access_deny_users: []

--- a/group_vars/workstations.yml
+++ b/group_vars/workstations.yml
@@ -1,0 +1,17 @@
+---
+# Kernel and GPU configuration
+list_v4: ['avx512f', 'avx512bw', 'avx512cd', 'avx512dq', 'avx512vl']
+list_v3: ['avx', 'avx2', 'bmi1', 'bmi2', 'f16c', 'fma', 'abm', 'movbe', 'xsave']
+list_v2: ['cx16', 'lahf_lm', 'popcnt', 'sse4_1', 'sse4_2', 'ssse3']
+list_v1: ['lm', 'cmov', 'cx8', 'fpu', 'fxsr', 'mmx', 'syscall', 'sse2']
+nvidia_version: nvidia-driver-590-open
+bad_nvidia_version: nvidia-driver-390
+
+# SLURM configuration
+slurm_version: 23.02.2
+slurm_tarball_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
+slurm_src_dir: "/tmp/slurm-{{ slurm_version }}"
+slurm_sbin_path: "/opt/slurm/current/sbin/slurmd"
+slurm_conf_path: "/opt/slurm/etc/slurm.conf"
+slurm_conf_dir: "/opt/slurm/etc"
+slurm_prefix_path: "/opt/slurm/{{ slurm_version }}"

--- a/inventory
+++ b/inventory
@@ -15,4 +15,3 @@ ciccs[01:13]
 [pi_workstations]
 cicws47
 cicws48
-cicws45

--- a/inventory
+++ b/inventory
@@ -7,7 +7,12 @@ cicws[16:31]
 cicws38
 cicws[41:48]
 cichm01
-dnpws[01:28]
+dnpws[01:30]
 
 [computenodes]
 ciccs[01:13]
+
+[pi_workstations]
+cicws47
+cicws48
+cicws45

--- a/roles/workstation/handlers/main.yml
+++ b/roles/workstation/handlers/main.yml
@@ -36,3 +36,14 @@
 
 - name: restart polkit
   service: name=polkit state=restarted
+
+- name: Validate ssh config
+  ansible.builtin.command: /usr/sbin/sshd -t
+  changed_when: false
+  listen: Validate and reload ssh
+
+- name: Reload ssh
+  ansible.builtin.service:
+    name: ssh
+    state: reloaded
+  listen: Validate and reload ssh

--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -11,3 +11,4 @@
 - {import_tasks: swap.yml, tags: swap}
 - {import_tasks: motd.yml, tags: motd}
 - {import_tasks: vmware.yml, tags: vmware}
+- {import_tasks: ssh-access.yml, tags: ssh}

--- a/roles/workstation/tasks/ssh-access.yml
+++ b/roles/workstation/tasks/ssh-access.yml
@@ -1,0 +1,70 @@
+- name: Ensure sshd_config.d exists
+  ansible.builtin.file:
+    path: /etc/ssh/sshd_config.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: ssh_access_policy_enabled | default(false) | bool
+
+- name: Check whether sshd_config includes sshd_config.d
+  ansible.builtin.command: >
+    grep -Eq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf'
+    /etc/ssh/sshd_config
+  register: sshd_include_check
+  changed_when: false
+  failed_when: sshd_include_check.rc not in [0, 1]
+  check_mode: false
+  when: ssh_access_policy_enabled | default(false) | bool
+
+- name: Add Include for sshd_config.d if missing
+  ansible.builtin.lineinfile:
+    path: /etc/ssh/sshd_config
+    insertafter: BOF
+    line: "Include /etc/ssh/sshd_config.d/*.conf"
+    owner: root
+    group: root
+    mode: "0644"
+  when:
+    - ssh_access_policy_enabled | default(false) | bool
+    - sshd_include_check.rc == 1
+  notify: restart ssh
+
+- name: Confirm allowed SSH groups exist
+  ansible.builtin.command: "getent group {{ item }}"
+  loop: "{{ ssh_access_allow_groups | default([]) }}"
+  changed_when: false
+  check_mode: false
+  when:
+    - ssh_access_policy_enabled | default(false) | bool
+    - ssh_access_allow_groups | default([]) | length > 0
+
+- name: Confirm Ansible SSH user is in an allowed group
+  ansible.builtin.command: "id -nG {{ ansible_ssh_user }}"
+  register: ansible_user_groups
+  changed_when: false
+  check_mode: false
+  when:
+    - ssh_access_policy_enabled | default(false) | bool
+    - ssh_access_allow_groups | default([]) | length > 0
+
+- name: Refuse to apply policy if Ansible user would be locked out
+  ansible.builtin.assert:
+    that:
+      - ansible_user_groups.stdout.split() | intersect(ssh_access_allow_groups | default([])) | length > 0
+    fail_msg: >
+      Refusing to apply SSH access policy. The Ansible SSH user {{ ansible_ssh_user }}
+      is not in any allowed group: {{ ssh_access_allow_groups | default([]) | join(', ') }}.
+  when:
+    - ssh_access_policy_enabled | default(false) | bool
+    - ssh_access_allow_groups | default([]) | length > 0
+
+- name: Install SSH access policy
+  ansible.builtin.template:
+    src: 50-ssh-access.conf.j2
+    dest: "{{ ssh_access_policy_file | default('/etc/ssh/sshd_config.d/50-ssh-access-policy.conf') }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: ssh_access_policy_enabled | default(false) | bool
+  notify: Validate and reload ssh

--- a/site.yml
+++ b/site.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: workstations
-  vars_files:
-    - vars/slurm.yml
-    - vars/kernel-nvidia.yml
   strategy: free
   become: yes
   roles:

--- a/templates/50-ssh-access.conf.j2
+++ b/templates/50-ssh-access.conf.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+{% if ssh_access_deny_users | default([]) | length > 0 %}
+DenyUsers {{ ssh_access_deny_users | join(' ') }}
+{% endif %}
+{% if ssh_access_deny_groups | default([]) | length > 0 %}
+DenyGroups {{ ssh_access_deny_groups | join(' ') }}
+{% endif %}
+{% if ssh_access_allow_users | default([]) | length > 0 %}
+AllowUsers {{ ssh_access_allow_users | join(' ') }}
+{% endif %}
+{% if ssh_access_allow_groups | default([]) | length > 0 %}
+AllowGroups {{ ssh_access_allow_groups | join(' ') }}
+{% endif %}

--- a/vars/kernel-nvidia.yml
+++ b/vars/kernel-nvidia.yml
@@ -1,7 +1,0 @@
----
-list_v4: ['avx512f', 'avx512bw', 'avx512cd', 'avx512dq', 'avx512vl']
-list_v3: ['avx', 'avx2', 'bmi1', 'bmi2', 'f16c', 'fma', 'abm', 'movbe', 'xsave']
-list_v2: ['cx16', 'lahf_lm', 'popcnt', 'sse4_1', 'sse4_2', 'ssse3']
-list_v1: ['lm', 'cmov', 'cx8', 'fpu', 'fxsr', 'mmx', 'syscall', 'sse2']
-nvidia_version: nvidia-driver-590-open
-bad_nvidia_version: nvidia-driver-390

--- a/vars/slurm.yml
+++ b/vars/slurm.yml
@@ -1,7 +1,0 @@
-slurm_version: 23.02.2
-slurm_tarball_url: "https://download.schedmd.com/slurm/slurm-{{ slurm_version }}.tar.bz2"
-slurm_src_dir: "/tmp/slurm-{{ slurm_version }}"
-slurm_sbin_path: "/opt/slurm/current/sbin/slurmd"
-slurm_conf_path: "/opt/slurm/etc/slurm.conf"
-slurm_conf_dir: "/opt/slurm/etc"
-slurm_prefix_path: "/opt/slurm/{{ slurm_version }}"


### PR DESCRIPTION
Create a reusable SSH access control system that restricts SSH logins based on group membership. PI machines now use AllowGroups to limit access to the 'pis' group (plus cicadministrators and sudo for admin access).

1- Add ssh-access task with validation checks to prevent lockout
2- Add SSH config template managed via sshd_config.d
3- Add handlers for SSH config validation and reload
4- Add group_vars for pi_workstations with access policy settings
5- remove vars folder, combine files into workstation.yml and put it in the group_vars folder (so it applies to only workstations)
6- Update inventory with pi_workstations group

I used claude for the git stuff and to review, it also suggested #5  